### PR TITLE
Correct PCB Factory Energy Hatch description

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PCBFactory.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PCBFactory.java
@@ -883,7 +883,18 @@ public class GT_MetaTileEntity_PCBFactory extends
             .beginStructureBlock(30, 38, 13, false)
             .addSeparator()
             .addMaintenanceHatch(EnumChatFormatting.GOLD + "1", 1)
-            .addEnergyHatch(EnumChatFormatting.GOLD + "1" + EnumChatFormatting.GRAY + "+", 1)
+            .addEnergyHatch(
+                EnumChatFormatting.GOLD + "1" 
+                    + EnumChatFormatting.GRAY
+                    + "-"
+                    + EnumChatFormatting.GOLD
+                    + "2"
+                    + EnumChatFormatting.GRAY
+                    + " or "
+                    + EnumChatFormatting.GOLD
+                    + "1"
+                    + EnumChatFormatting.GRAY
+                    + " TT energy hatch.", 1)
             .addInputBus(EnumChatFormatting.GOLD + "1" + EnumChatFormatting.GRAY + "+", 1)
             .addOutputBus(EnumChatFormatting.GOLD + "1" + EnumChatFormatting.GRAY + "+", 1)
             .addInputHatch(EnumChatFormatting.GOLD + "1" + EnumChatFormatting.GRAY + "+", 1)


### PR DESCRIPTION
When attempting to upgrade my PCB Factory I was surprised by the PCB factory apparently being limited to 2 energy hatches when the tooltip says "1+"

The intent of this PR is to change the PCB factory description (the one seen when holding shift) which currently says "Energy Hatches: 1+" I believe this is incorrect and that the correct description is 1-2 energy hatches or 1 TT energy hatch.

I believe the PCB factory uses this function, which checks for 1-2 or 1 TT energy hatch:
/**
@return Returns true if there is 1 TT Energy Hatch OR up to 2 Energy Hatches*/
public boolean checkExoticAndNormalEnergyHatches() 
